### PR TITLE
Initial trng driver

### DIFF
--- a/golf2/apps/rng/Makefile
+++ b/golf2/apps/rng/Makefile
@@ -1,0 +1,21 @@
+CURRENT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+TOCK_ARCH ?= cortex-m3
+TOCK_BASE_DIR = $(CURRENT_DIR)/../../../tock/userland
+BUILDDIR ?= $(CURRENT_DIR)/build/$(TOCK_ARCH)
+
+C_SRCS   := $(wildcard *.c)
+
+OBJS += $(patsubst %.c,$(BUILDDIR)/%.o,$(C_SRCS))
+
+CPPFLAGS += -DSTACK_SIZE=2048
+
+include $(TOCK_BASE_DIR)/Makefile
+
+$(BUILDDIR)/%.o: %.c | $(BUILDDIR)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
+
+.PHONY:
+clean:
+	rm -Rf $(BUILDDIR)
+

--- a/golf2/apps/rng/rng.c
+++ b/golf2/apps/rng/rng.c
@@ -3,16 +3,54 @@
 #include <stdio.h>
 #include <tock.h>
 
+struct rng_data {
+  bool done;
+  int len;
+};
+
+static void rng_cb( int len,
+                    __attribute__ ((unused)) int unused0,
+                    __attribute__ ((unused)) int unused1,
+                    void* ud) {
+  struct rng_data* data = (struct rng_data*) ud;
+  data->len = len;
+  data->done = true;
+}
+
+static int get_random(void *buf, int len) {
+  int err = allow(5, 0, buf, len);
+  if (err < 0) {
+      return err;
+  }
+
+  struct rng_data data = { false, 0 };
+
+  err = subscribe(5, 0, rng_cb, &data);
+  if (err < 0) {
+    return err;
+  }
+
+  err = command(5, 0, 0);
+  if (err < 0) {
+    return err;
+  }
+
+  yield_for(&data.done);
+
+  return data.len;
+}
+
 int main(void) {
   printf("Hello from the RNG application!\n");
 
-  uint32_t buf;
-  int err = allow(5, 0, &buf, 4);
-  while (err == 0) {
-    printf("Have some random bytes: 0x%lx\n\n", buf);
+  char buf[1000];
+  int len = get_random(buf, sizeof(buf));
+  while (len > 0) {
+    printf("Read %d bytes of random data.\n", len);
+    printf("Sample data = 0x%08lx\n", *(unsigned long *)buf);
     delay_ms(1000);
-    err = allow(5, 0, &buf, 4);
+    len = get_random(buf, sizeof(buf));
   }
 
-  return err;
+  return 0;
 }

--- a/golf2/apps/rng/rng.c
+++ b/golf2/apps/rng/rng.c
@@ -1,0 +1,18 @@
+#include <firestorm.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <tock.h>
+
+int main(void) {
+  printf("Hello from the RNG application!\n");
+
+  uint32_t buf;
+  int err = allow(5, 0, &buf, 4);
+  while (err == 0) {
+    printf("Have some random bytes: 0x%lx\n\n", buf);
+    delay_ms(1000);
+    err = allow(4, 0, &buf, 4);
+  }
+
+  return err;
+}

--- a/golf2/apps/rng/rng.c
+++ b/golf2/apps/rng/rng.c
@@ -11,7 +11,7 @@ int main(void) {
   while (err == 0) {
     printf("Have some random bytes: 0x%lx\n\n", buf);
     delay_ms(1000);
-    err = allow(4, 0, &buf, 4);
+    err = allow(5, 0, &buf, 4);
   }
 
   return err;

--- a/golf2/src/rng.rs
+++ b/golf2/src/rng.rs
@@ -1,0 +1,27 @@
+use hotel::hil::rng::Rng;
+use kernel::{AppId, AppSlice, Driver, Shared};
+use kernel::common::take_cell::TakeCell;
+
+/// Driver for a random number generator, using the Rng trait.
+pub struct RngDriver<'a, G: Rng + 'a> {
+    rng: TakeCell<&'a mut G>,
+}
+
+impl<'a, G: Rng + 'a> RngDriver<'a, G> {
+    /// Creates a new RngDriver.
+    pub fn new(rng: &'a mut G) -> RngDriver<'a, G> {
+        RngDriver { rng: TakeCell::new(rng) }
+    }
+}
+
+impl<'a, G: Rng + 'a> Driver for RngDriver<'a, G> {
+    /// Fills an application-provided buffer with random bytes.
+    fn allow(&self, _: AppId, _: usize, mut slice: AppSlice<Shared, u8>) -> isize {
+        self.rng
+            .map(|rng| {
+                rng.fill_bytes(slice.as_mut());
+                0
+            })
+            .unwrap_or(-1)
+    }
+}

--- a/golf2/src/rng.rs
+++ b/golf2/src/rng.rs
@@ -1,27 +1,137 @@
-use hotel::hil::rng::Rng;
-use kernel::{AppId, AppSlice, Driver, Shared};
+use hotel::hil::rng::{Continue, Rng, RngClient};
+use kernel::{AppId, AppSlice, Callback, Container, Driver, Shared};
 use kernel::common::take_cell::TakeCell;
+
+pub struct App {
+    callback: Option<Callback>,
+    buffer: Option<AppSlice<Shared, u8>>,
+    offset: usize,
+}
+
+impl Default for App {
+    fn default() -> App {
+        App {
+            callback: None,
+            buffer: None,
+            offset: usize::max_value(),
+        }
+    }
+}
 
 /// Driver for a random number generator, using the Rng trait.
 pub struct RngDriver<'a, G: Rng + 'a> {
     rng: TakeCell<&'a mut G>,
+    apps: Container<App>,
 }
 
 impl<'a, G: Rng + 'a> RngDriver<'a, G> {
     /// Creates a new RngDriver.
-    pub fn new(rng: &'a mut G) -> RngDriver<'a, G> {
-        RngDriver { rng: TakeCell::new(rng) }
+    pub fn new(rng: &'a mut G, container: Container<App>) -> RngDriver<'a, G> {
+        RngDriver {
+            rng: TakeCell::new(rng),
+            apps: container,
+        }
     }
 }
 
 impl<'a, G: Rng + 'a> Driver for RngDriver<'a, G> {
-    /// Fills an application-provided buffer with random bytes.
-    fn allow(&self, _: AppId, _: usize, mut slice: AppSlice<Shared, u8>) -> isize {
-        self.rng
-            .map(|rng| {
-                rng.fill_bytes(slice.as_mut());
-                0
-            })
-            .unwrap_or(-1)
+    /// Saves an application-provided buffer to be filled with random data.
+    fn allow(&self, app_id: AppId, _: usize, slice: AppSlice<Shared, u8>) -> isize {
+        self.apps.enter(app_id, |app, _| {
+            app.buffer = Some(slice);
+            app.offset = 0;
+            0
+        }).unwrap_or(-1)
     }
+
+    /// Saves an application-provided callback that will be used to notify
+    /// the application when the provided buffer is full.
+    fn subscribe(&self, _: usize, callback: Callback) -> isize {
+        self.apps.enter(callback.app_id(), |app, _| {
+            app.callback = Some(callback);
+            0
+        }).unwrap_or(-1)
+    }
+
+    /// Instructs the driver to begin filling the application-provided buffer with
+    /// random data.  If the application has not provided both a buffer to fill and
+    /// a notification callback this will return an error.
+    fn command(&self, _: usize, _: usize, app_id: AppId) -> isize {
+        self.apps.enter(app_id, |app, _| {
+            if app.callback.is_none() || app.buffer.is_none() {
+                return -1;
+            }
+
+            self.rng.map(|rng| {
+                rng.get_data();
+                0
+            }).unwrap_or(-1)
+        }).unwrap_or(-1)
+    }
+}
+
+impl<'a, G: Rng + 'a> RngClient for RngDriver<'a, G> {
+    fn random_data_available(&self, iter: &mut Iterator<Item = u32>) -> Continue {
+        for container in self.apps.iter() {
+            let finished = container.enter(|app, _| {
+                if app.callback.is_none() || app.buffer.is_none() {
+                    // These may not be fully set up yet.
+                    return true;
+                }
+
+                // Take the buffer out.
+                let mut slice = app.buffer.take().unwrap();
+                {
+                    // Fill the buffer with random data.
+                    let buf: &mut [u8] = slice.as_mut();
+                    while let Some(data) = iter.next() {
+                        if app.offset >= buf.len() {
+                            break
+                        }
+
+                        let diff = buf.len() - app.offset;
+                        let data = u32_to_byte_array(data);
+                        if diff > 4 {
+                            buf[app.offset..app.offset+4].copy_from_slice(&data);
+                            app.offset += 4;
+                        } else {
+                            buf[app.offset..].copy_from_slice(&data[..diff]);
+                            app.offset += diff;
+                        }
+                    }
+                }
+                // Put the buffer back.
+                app.buffer = Some(slice);
+
+                if app.offset < app.buffer.as_ref().unwrap().len() {
+                    return false;
+                }
+
+                // The buffer is full.  Notify the application.
+                app.callback.map(|mut cb| cb.schedule(app.offset, 0, 0));
+
+                // Reset the Container
+                app.callback = None;
+                app.buffer = None;
+                app.offset = usize::max_value();
+
+                true
+            });
+
+            if !finished {
+                return Continue::More;
+            }
+        }
+
+        Continue::Done
+    }
+}
+
+fn u32_to_byte_array(x: u32) -> [u8; 4] {
+    let x1 = (x & 0xff) as u8;
+    let x2 = ((x >> 8) & 0xff) as u8;
+    let x3 = ((x >> 16) & 0xff) as u8;
+    let x4 = ((x >> 24) & 0xff) as u8;
+
+    [x1, x2, x3, x4]
 }

--- a/hotel/src/chip.rs
+++ b/hotel/src/chip.rs
@@ -3,6 +3,7 @@ use crypto;
 use gpio;
 use kernel::Chip;
 use timels;
+use trng;
 use uart;
 use usb;
 
@@ -39,6 +40,8 @@ impl Chip for Hotel {
 
                     159 => timels::Timels0.handle_interrupt(),
                     160 => timels::Timels1.handle_interrupt(),
+
+                    169 => trng::TRNG0.handle_interrupt(),
 
                     174 => uart::UART0.handle_rx_interrupt(),
                     177 => uart::UART0.handle_tx_interrupt(),

--- a/hotel/src/hil/mod.rs
+++ b/hotel/src/hil/mod.rs
@@ -1,3 +1,4 @@
 pub mod common;
 pub mod digest;
 pub mod aes;
+pub mod rng;

--- a/hotel/src/hil/rng.rs
+++ b/hotel/src/hil/rng.rs
@@ -1,0 +1,25 @@
+/// A Random Number Generator, based on the Rng trait from the rand crate.
+pub trait Rng {
+    /// Returns 4 bytes of random data.  Types that implement the Rng trait
+    /// only need to implement this function.
+    fn next_u32(&mut self) -> u32;
+
+    /// Fills an arbitrarily sized buffer with random data.  The default
+    /// implementation is based on next_u32().  Implementations that can fulfill
+    /// the requirements more efficiently may wish to override this implementation
+    /// for performance.
+    fn fill_bytes(&mut self, buf: &mut [u8]) {
+        let mut rem = 0;
+        let mut data = 0;
+        for byte in buf.iter_mut() {
+            if rem == 0 {
+                data = self.next_u32();
+                rem = 4;
+            }
+
+            *byte = (data & 0xff) as u8;
+            data >>= 8;
+            rem -= 1;
+        }
+    }
+}

--- a/hotel/src/hil/rng.rs
+++ b/hotel/src/hil/rng.rs
@@ -1,25 +1,15 @@
-/// A Random Number Generator, based on the Rng trait from the rand crate.
+//! Interfaces for accessing a random number generator.
+
+#[derive(Eq, PartialEq)]
+pub enum Continue {
+    More,
+    Done,
+}
+
 pub trait Rng {
-    /// Returns 4 bytes of random data.  Types that implement the Rng trait
-    /// only need to implement this function.
-    fn next_u32(&mut self) -> u32;
+    fn get_data(&self);
+}
 
-    /// Fills an arbitrarily sized buffer with random data.  The default
-    /// implementation is based on next_u32().  Implementations that can fulfill
-    /// the requirements more efficiently may wish to override this implementation
-    /// for performance.
-    fn fill_bytes(&mut self, buf: &mut [u8]) {
-        let mut rem = 0;
-        let mut data = 0;
-        for byte in buf.iter_mut() {
-            if rem == 0 {
-                data = self.next_u32();
-                rem = 4;
-            }
-
-            *byte = (data & 0xff) as u8;
-            data >>= 8;
-            rem -= 1;
-        }
-    }
+pub trait RngClient {
+    fn random_data_available(&self, &mut Iterator<Item = u32>) -> Continue;
 }

--- a/hotel/src/lib.rs
+++ b/hotel/src/lib.rs
@@ -17,6 +17,7 @@ pub mod pinmux;
 pub mod pmu;
 pub mod timels;
 pub mod timeus;
+pub mod trng;
 pub mod uart;
 pub mod usb;
 

--- a/hotel/src/trng.rs
+++ b/hotel/src/trng.rs
@@ -203,4 +203,3 @@ impl<'a> Iterator for Iter<'a> {
         }
     }
 }
-

--- a/hotel/src/trng.rs
+++ b/hotel/src/trng.rs
@@ -1,0 +1,157 @@
+//! Driver for the True Random Number Generator (TRNG).
+
+use hil::rng::Rng;
+use kernel::common::volatile_cell::VolatileCell;
+
+#[allow(dead_code)]
+#[repr(C, packed)]
+struct Registers {
+    /// TRNG version.  Defaults to 0x2d013316.
+    _version: VolatileCell<u32>,
+
+    /// Enable interrupts.
+    interrupt_enable: VolatileCell<u32>,
+
+    /// Current state of interrupts.
+    interrupt_state: VolatileCell<u32>,
+
+    /// Used to test interrupts.
+    interrupt_test: VolatileCell<u32>,
+
+    /// High permission register to control which post-processing techniques
+    /// should be turned on.
+    secure_post_processing_control: VolatileCell<u32>,
+
+    /// Medium permission register to control post-processing techniques.
+    post_processing_control: VolatileCell<u32>,
+
+    /// Single pulse from the processor to initiate the digital TRNG by moving the
+    /// FSM from the idle to the active calibrated stage.
+    go_event: VolatileCell<u32>,
+
+    /// Counter for the timeout that determines how long the digital TRNG will wait
+    /// for its analog counterpart.
+    timeout_counter: VolatileCell<u32>,
+
+    /// Maximum number of times the digital segment can timeout before interrupting
+    /// the processor.
+    timeout_max_try_num: VolatileCell<u32>,
+
+    /// Random output refresh counter.  Every N cycles, the TRNG sends the random
+    /// bits output to local modules, stopping its current state.
+    output_time_counter: VolatileCell<u32>,
+
+    /// Single pulse from the processor to shut down the TRNG by resetting the digital
+    /// side to the idle state and save power.
+    stop_work: VolatileCell<u32>,
+
+    /// Debug register for keeping track of the FSM state.
+    fsm_state: VolatileCell<u32>,
+
+    /// Used to control the programmable minimum and maximum value that can be
+    /// produced by the analog component.
+    allowed_values: VolatileCell<u32>,
+
+    /// Reflects the current time counter value that the TRNG has while waiting for
+    /// its analog counterpart.
+    timer_counter: VolatileCell<u32>,
+
+    /// Most significant bits for the slicing portion that are used during calibration.
+    slice_max_upper_limit: VolatileCell<u32>,
+
+    /// Least significant bits for the slicing portion that are used during calibration.
+    slice_min_lower_limit: VolatileCell<u32>,
+
+    /// Maximum value seen during calibration.
+    max_value: VolatileCell<u32>,
+
+    /// Minimum value seen during calibration.
+    min_value: VolatileCell<u32>,
+
+    /// Reflects the current LDO settings from the processor and sends it to the analog TRNG.
+    ldo_ctrl: VolatileCell<u32>,
+
+    /// Powers down all the components of the TRNG when asserted low.
+    power_down_b: VolatileCell<u32>,
+
+    /// High permission register to disable power down control by application.
+    proc_lock_power_down_b: VolatileCell<u32>,
+
+    /// Analog test control.
+    antest: VolatileCell<u32>,
+
+    /// Input controls to laser detector unit.
+    analog_sen_lsr_input: VolatileCell<u32>,
+
+    /// Output controls to the laser detector unit.
+    analog_sen_lsr_output: VolatileCell<u32>,
+
+    /// Guides controls during device state testing.
+    analog_test: VolatileCell<u32>,
+
+    /// Control register to pass values to different analog controls.
+    analog_ctrl: VolatileCell<u32>,
+
+    /// Enables the TRNG one shot mode.
+    one_shot_mode: VolatileCell<u32>,
+
+    /// Stores the 16-bit output from the analog unit when one shot mode is enabled.
+    one_shot_register: VolatileCell<u32>,
+
+    /// TRNG output.
+    read_data: VolatileCell<u32>,
+
+    /// Indicates the number of times the processor asserts the TRNG_READ signal to get
+    /// a fresh set of random 32 bits.  Cumulative until cleared by the processor.
+    frequency_calls: VolatileCell<u32>,
+
+    /// Indicates the number of bits that have the value of 1 among the total bits read
+    /// by the digital part of the TRNG.
+    cur_num_ones: VolatileCell<u32>,
+
+    /// Indicates that the TRNG is currently empty.
+    empty: VolatileCell<u32>,
+}
+
+const TRNG0_BASE: *mut Registers = 0x40410000 as *mut Registers;
+
+pub static mut TRNG0: TRNG = unsafe { TRNG::new(TRNG0_BASE) };
+
+pub struct TRNG {
+    regs: *mut Registers,
+}
+
+impl TRNG {
+    const unsafe fn new(trng: *mut Registers) -> TRNG {
+        TRNG { regs: trng }
+    }
+
+    pub fn init(&self) {
+        let regs = unsafe { &*self.regs };
+
+        // Enable bit shuffling and churn mode.  Disable XOR and Von Neumann processing.
+        regs.post_processing_control.set(0xa);
+        regs.slice_max_upper_limit.set(1);
+        regs.slice_min_lower_limit.set(0);
+        regs.timeout_counter.set(0x7ff);
+        regs.timeout_max_try_num.set(4);
+        regs.power_down_b.set(1);
+        regs.go_event.set(1);
+    }
+}
+
+impl Rng for TRNG {
+    fn next_u32(&mut self) -> u32 {
+        let regs = unsafe { &*self.regs };
+
+        while regs.empty.get() > 0 {
+            if regs.fsm_state.get() & 0x8 != 0 {
+                // TRNG timed out, restart.
+                regs.stop_work.set(1);
+                regs.go_event.set(1);
+            }
+        }
+
+        regs.read_data.get()
+    }
+}


### PR DESCRIPTION
This patch includes four components:

 * A driver for the TRNG on the golf2 board.
 * An Rng trait in the hil crate.  The TRNG implements this trait.
 * A Driver that uses the Rng trait from the hil to provide random data
   to userland applications.  Applications request random data by making
   an allow syscall with a provided buffer.
 * An example userland application that fetches random data from the
   TRNG via the Rng driver.

Signed-off-by: Chirantan Ekbote <chirantan@google.com>